### PR TITLE
Make slippage as param & combine yield strategy setters

### DIFF
--- a/contracts/libraries/Logic.sol
+++ b/contracts/libraries/Logic.sol
@@ -33,7 +33,7 @@ library Logic {
     event FeesUpdated(uint256 fee);
     event FeesWithdrawn(uint256 total);
 
-    event SettersUpdated(
+    event CurveParamsUpdated(
         uint256 feeBps,
         uint256 stablecoinSlippage,
         uint256 crvHarvestThreshold,

--- a/contracts/libraries/Logic.sol
+++ b/contracts/libraries/Logic.sol
@@ -30,12 +30,17 @@ library Logic {
     event Harvested(uint256 crvAmount);
     event Staked(uint256 amount, address indexed depositor);
 
-    event FeesWithdrawn(uint256 total);
     event FeesUpdated(uint256 fee);
+    event FeesWithdrawn(uint256 total);
 
-    event CrvOracleUpdated(address indexed oracle);
-    event CrvHarvestThresholdUpdated(uint256 threshold);
-    event CrvSwapSlippageToleranceUpdated(uint256 tolerance);
+    event SettersUpdated(
+        uint256 feeBps,
+        uint256 stablecoinSlippage,
+        uint256 crvHarvestThreshold,
+        uint256 crvSlippageTolerance,
+        address indexed crvOracle
+    );
+
     event CrvSwapFailedDueToSlippage(uint256 crvSlippageTolerance);
 
     event EightyTwentyParamsUpdated(
@@ -153,6 +158,7 @@ library Logic {
     // curve yield strategy
     function convertAssetToSettlementToken(
         uint256 amount,
+        uint256 slippage,
         ILPPriceGetter lpPriceHolder,
         ICurveGauge gauge,
         ICurveStableSwap triCryptoPool,
@@ -170,7 +176,7 @@ library Logic {
 
         bytes memory path = abi.encodePacked(usdt, uint24(500), usdc);
 
-        usdcAmount = SwapManager.swapUsdtToUsdc(balance, path, uniV3Router);
+        usdcAmount = SwapManager.swapUsdtToUsdc(balance, slippage, path, uniV3Router);
     }
 
     function getMarketValue(uint256 amount, ILPPriceGetter lpPriceHolder) external view returns (uint256 marketValue) {

--- a/contracts/libraries/SwapManager.sol
+++ b/contracts/libraries/SwapManager.sol
@@ -22,13 +22,12 @@ library SwapManager {
 
     function swapUsdcToUsdtAndAddLiquidity(
         uint256 amount,
+        uint256 slippage,
         bytes memory path,
         ISwapRouter uniV3Router,
         ICurveStableSwap triCrypto
     ) external {
-        /// @dev max 1% sliipage + fees when swapping usdc to usdt
-        /// @notice 9_000 is used for test cases, will be changed to 9900
-        uint256 minOut = (amount * 9_000) / MAX_BPS;
+        uint256 minOut = (amount * (MAX_BPS - slippage)) / MAX_BPS;
 
         ISwapRouter.ExactInputParams memory params = ISwapRouter.ExactInputParams({
             path: path,
@@ -47,12 +46,11 @@ library SwapManager {
 
     function swapUsdtToUsdc(
         uint256 amount,
+        uint256 slippage,
         bytes memory path,
         ISwapRouter uniV3Router
     ) external returns (uint256 usdcOut) {
-        /// @dev max 1% sliipage + fees when swapping usdt to usdc
-        /// @notice 9_000 is used for test cases, will be changed to 9900
-        uint256 minOut = (amount * 9_000) / MAX_BPS;
+        uint256 minOut = (amount * (MAX_BPS - slippage)) / MAX_BPS;
 
         ISwapRouter.ExactInputParams memory params = ISwapRouter.ExactInputParams({
             path: path,

--- a/contracts/yieldStrategy/CurveYieldStrategy.sol
+++ b/contracts/yieldStrategy/CurveYieldStrategy.sol
@@ -80,7 +80,7 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
         lpPriceHolder = params.lpPriceHolder;
     }
 
-    function updateSetters(
+    function updateCurveParams(
         uint256 _feeBps,
         uint256 _stablecoinSlippage,
         uint256 _crvHarvestThreshold,
@@ -101,7 +101,7 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
         if (address(_crvOracle) != address(0)) crvOracle = _crvOracle;
         else revert CYS_INVALID_SETTER_VALUE(0);
 
-        emit Logic.SettersUpdated(
+        emit Logic.CurveParamsUpdated(
             _feeBps,
             _stablecoinSlippage,
             _crvHarvestThreshold,

--- a/contracts/yieldStrategy/CurveYieldStrategy.sol
+++ b/contracts/yieldStrategy/CurveYieldStrategy.sol
@@ -25,7 +25,7 @@ import { Logic } from '../libraries/Logic.sol';
 contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
     using FullMath for uint256;
 
-    error CYS_INVALID_FEES();
+    error CYS_INVALID_SETTER_VALUE(uint256 value);
     error CYS_EXTERAL_CALL_FAILED(string reason);
 
     IERC20 private usdt; // 6 decimals
@@ -87,18 +87,19 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
         uint256 _crvSlippageTolerance,
         AggregatorV3Interface _crvOracle
     ) external onlyOwner {
-        if (_feeBps < MAX_BPS && _feeBps != FEE) FEE = _feeBps;
+        if (_feeBps < MAX_BPS) FEE = _feeBps;
+        else revert CYS_INVALID_SETTER_VALUE(_feeBps);
 
-        if (_stablecoinSlippage < MAX_BPS && _stablecoinSlippage != stablecoinSlippageTolerance)
-            stablecoinSlippageTolerance = _stablecoinSlippage;
+        if (_stablecoinSlippage < MAX_BPS) stablecoinSlippageTolerance = _stablecoinSlippage;
+        else revert CYS_INVALID_SETTER_VALUE(_stablecoinSlippage);
 
-        if (_crvHarvestThreshold < MAX_BPS && _crvHarvestThreshold != crvHarvestThreshold)
-            crvHarvestThreshold = _crvHarvestThreshold;
+        crvHarvestThreshold = _crvHarvestThreshold;
 
-        if (_crvSlippageTolerance < MAX_BPS && _crvSlippageTolerance != crvSwapSlippageTolerance)
-            crvSwapSlippageTolerance = _crvSlippageTolerance;
+        if (_crvSlippageTolerance < MAX_BPS) crvSwapSlippageTolerance = _crvSlippageTolerance;
+        else revert CYS_INVALID_SETTER_VALUE(_stablecoinSlippage);
 
-        if (address(_crvOracle) != address(0) && _crvOracle != crvOracle) crvOracle = _crvOracle;
+        if (address(_crvOracle) != address(0)) crvOracle = _crvOracle;
+        else revert CYS_INVALID_SETTER_VALUE(0);
 
         emit Logic.SettersUpdated(
             _feeBps,

--- a/contracts/yieldStrategy/CurveYieldStrategy.sol
+++ b/contracts/yieldStrategy/CurveYieldStrategy.sol
@@ -43,6 +43,7 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
     uint256 private crvPendingToSwap; // in CRV (10**18)
     uint256 private crvHarvestThreshold; // in CRV (10**18)
     uint256 private crvSwapSlippageTolerance; // in bps, max 10**4
+    uint256 private stablecoinSlippageTolerance; // in bps, max 10**4
 
     /* solhint-disable var-name-mixedcase */
     uint256 public constant MAX_BPS = 10_000;
@@ -79,25 +80,33 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
         lpPriceHolder = params.lpPriceHolder;
     }
 
-    /// @notice Sets the CRV to USD oracle address
-    /// @param _crvOracle address of oracle
-    function setCrvOracle(AggregatorV3Interface _crvOracle) external onlyOwner {
-        crvOracle = _crvOracle;
-        emit Logic.CrvOracleUpdated(address(_crvOracle));
-    }
+    function updateSetters(
+        uint256 _feeBps,
+        uint256 _stablecoinSlippage,
+        uint256 _crvHarvestThreshold,
+        uint256 _crvSlippageTolerance,
+        AggregatorV3Interface _crvOracle
+    ) external onlyOwner {
+        if (_feeBps < MAX_BPS && _feeBps != FEE) FEE = _feeBps;
 
-    /// @notice Sets the max allowed slippage tolerance for CRV->WETH->USDT swap
-    /// @param _slippageTolerance value in bps unit for slippage tolerance
-    function setCrvSwapSlippageTolerance(uint256 _slippageTolerance) external onlyOwner {
-        crvSwapSlippageTolerance = _slippageTolerance;
-        emit Logic.CrvSwapSlippageToleranceUpdated(_slippageTolerance);
-    }
+        if (_stablecoinSlippage < MAX_BPS && _stablecoinSlippage != stablecoinSlippageTolerance)
+            stablecoinSlippageTolerance = _stablecoinSlippage;
 
-    /// @notice Sets the minimum threshold to harvest CRV rewards
-    /// @param _crvHarvestThreshold minimum threshold value (in CRV)
-    function setcrvHarvestThreshold(uint256 _crvHarvestThreshold) external onlyOwner {
-        crvHarvestThreshold = _crvHarvestThreshold;
-        emit Logic.CrvHarvestThresholdUpdated(_crvHarvestThreshold);
+        if (_crvHarvestThreshold < MAX_BPS && _crvHarvestThreshold != crvHarvestThreshold)
+            crvHarvestThreshold = _crvHarvestThreshold;
+
+        if (_crvSlippageTolerance < MAX_BPS && _crvSlippageTolerance != crvSwapSlippageTolerance)
+            crvSwapSlippageTolerance = _crvSlippageTolerance;
+
+        if (address(_crvOracle) != address(0) && _crvOracle != crvOracle) crvOracle = _crvOracle;
+
+        emit Logic.SettersUpdated(
+            _feeBps,
+            _stablecoinSlippage,
+            _crvHarvestThreshold,
+            _crvSlippageTolerance,
+            address(_crvOracle)
+        );
     }
 
     /// @notice grants one time max allowance to various third parties
@@ -117,14 +126,6 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
         usdt.approve(address(triCryptoPool), type(uint256).max);
 
         crvToken.approve(address(uniV3Router), type(uint256).max);
-    }
-
-    /// @notice changes the fee value for CRV yield generated
-    /// @param bps new fee value (less than MAX_BPS)
-    function changeFee(uint256 bps) external onlyOwner {
-        if (bps > MAX_BPS) revert CYS_INVALID_FEES();
-        FEE = bps;
-        emit Logic.FeesUpdated(bps);
     }
 
     /// @notice withdraw accumulated CRV fees
@@ -153,7 +154,13 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
     /// @param amount amount of settlementToken
     function _convertSettlementTokenToAsset(uint256 amount) internal override {
         bytes memory path = abi.encodePacked(usdc, uint24(500), usdt);
-        SwapManager.swapUsdcToUsdtAndAddLiquidity(amount, path, uniV3Router, triCryptoPool);
+        SwapManager.swapUsdcToUsdtAndAddLiquidity(
+            amount,
+            stablecoinSlippageTolerance,
+            path,
+            uniV3Router,
+            triCryptoPool
+        );
         _stake(asset.balanceOf(address(this)));
     }
 
@@ -220,7 +227,16 @@ contract CurveYieldStrategy is EightyTwentyRangeStrategyVault {
     /// @param amount amount of LP tokens
     function _convertAssetToSettlementToken(uint256 amount) internal override returns (uint256 usdcAmount) {
         return
-            Logic.convertAssetToSettlementToken(amount, lpPriceHolder, gauge, triCryptoPool, usdt, uniV3Router, usdc);
+            Logic.convertAssetToSettlementToken(
+                amount,
+                stablecoinSlippageTolerance,
+                lpPriceHolder,
+                gauge,
+                triCryptoPool,
+                usdt,
+                uniV3Router,
+                usdc
+            );
     }
 
     /// @notice compute notional value for given amount of LP tokens

--- a/test/CurveYieldStrategy.spec.ts
+++ b/test/CurveYieldStrategy.spec.ts
@@ -43,7 +43,9 @@ describe('CurveYieldStrategy', () => {
       ]);
 
       expect(before.toString()).to.be.eql(zeroBN.toString());
-      expect(after.toString()).to.be.eql([ethers.constants.MaxUint256, ethers.constants.MaxUint256, ethers.constants.MaxUint256].toString());
+      expect(after.toString()).to.be.eql(
+        [ethers.constants.MaxUint256, ethers.constants.MaxUint256, ethers.constants.MaxUint256].toString(),
+      );
     });
 
     it('should transfer lp tokens & mint shares', async () => {
@@ -752,7 +754,7 @@ describe('CurveYieldStrategy', () => {
       await hre.network.provider.send('evm_increaseTime', [10_000_000]);
       await hre.network.provider.send('evm_mine', []);
 
-      await curveYieldStrategy.setCrvSwapSlippageTolerance(100);
+      await curveYieldStrategy.connect(admin).updateCurveParams(1000, 4_000, 0, 100, addresses.CRV_ORACLE);
 
       await gauge.claimable_reward_write(curveYieldStrategy.address, crv.address);
       const claimable_ = await gauge.claimable_reward(curveYieldStrategy.address, crv.address);

--- a/test/CurveYieldStrategy.spec.ts
+++ b/test/CurveYieldStrategy.spec.ts
@@ -677,7 +677,7 @@ describe('CurveYieldStrategy', () => {
       const curveYieldStrategy = curveYieldStrategyTest.connect(admin);
       await curveYieldStrategy.grantAllowances();
 
-      await curveYieldStrategy.changeFee(2000);
+      await curveYieldStrategy.updateSetters(2_000, 1_000, 0, 3_000, addresses.CRV_ORACLE);
       expect(await curveYieldStrategy.FEE()).to.be.eq(BigNumber.from(2000));
     });
 
@@ -687,7 +687,9 @@ describe('CurveYieldStrategy', () => {
       const curveYieldStrategy = curveYieldStrategyTest.connect(admin);
       await curveYieldStrategy.grantAllowances();
 
-      await expect(curveYieldStrategy.changeFee(10001)).to.be.revertedWith('CYS_INVALID_FEES');
+      await expect(
+        curveYieldStrategyTest.updateSetters(2_000, 1_000, 0, 3_000, addresses.CRV_ORACLE),
+      ).to.be.revertedWith('CYS_INVALID_FEES');
     });
 
     it('should not trigger crv slippage tolerance', async () => {

--- a/test/CurveYieldStrategy.spec.ts
+++ b/test/CurveYieldStrategy.spec.ts
@@ -32,6 +32,7 @@ describe('CurveYieldStrategy', () => {
         usdt.allowance(curveYieldStrategy.address, addresses.TRICRYPTO_POOL),
         lpToken.allowance(curveYieldStrategy.address, addresses.TRICRYPTO_POOL),
       ]);
+      const zeroBN = Array<BigNumber>(3).fill(BigNumber.from(0))
 
       await curveYieldStrategy.grantAllowances();
 
@@ -41,10 +42,8 @@ describe('CurveYieldStrategy', () => {
         lpToken.allowance(curveYieldStrategy.address, addresses.TRICRYPTO_POOL),
       ]);
 
-      expect(before.toString()).to.be.eql([BigNumber.from(0), BigNumber.from(0), BigNumber.from(0)].toString());
-      expect(after.toString()).to.be.eql(
-        [ethers.constants.MaxUint256, ethers.constants.MaxUint256, ethers.constants.MaxUint256].toString(),
-      );
+      expect(before.toString()).to.be.eql(zeroBN.toString());
+      expect(after.toString()).to.be.eql([ethers.constants.MaxUint256, ethers.constants.MaxUint256, ethers.constants.MaxUint256].toString());
     });
 
     it('should transfer lp tokens & mint shares', async () => {
@@ -688,7 +687,7 @@ describe('CurveYieldStrategy', () => {
       await curveYieldStrategy.grantAllowances();
 
       await expect(
-        curveYieldStrategyTest.updateSetters(2_000, 1_000, 0, 3_000, addresses.CRV_ORACLE),
+        curveYieldStrategyTest.updateSetters(10_001, 1_000, 0, 3_000, addresses.CRV_ORACLE),
       ).to.be.revertedWith('CYS_INVALID_FEES');
     });
 

--- a/test/CurveYieldStrategy.spec.ts
+++ b/test/CurveYieldStrategy.spec.ts
@@ -32,7 +32,7 @@ describe('CurveYieldStrategy', () => {
         usdt.allowance(curveYieldStrategy.address, addresses.TRICRYPTO_POOL),
         lpToken.allowance(curveYieldStrategy.address, addresses.TRICRYPTO_POOL),
       ]);
-      const zeroBN = Array<BigNumber>(3).fill(BigNumber.from(0))
+      const zeroBN = Array<BigNumber>(3).fill(BigNumber.from(0));
 
       await curveYieldStrategy.grantAllowances();
 

--- a/test/CurveYieldStrategy.spec.ts
+++ b/test/CurveYieldStrategy.spec.ts
@@ -688,7 +688,7 @@ describe('CurveYieldStrategy', () => {
 
       await expect(
         curveYieldStrategyTest.updateSetters(10_001, 1_000, 0, 3_000, addresses.CRV_ORACLE),
-      ).to.be.revertedWith('CYS_INVALID_FEES');
+      ).to.be.revertedWith('CYS_INVALID_SETTER_VALUE(10001)');
     });
 
     it('should not trigger crv slippage tolerance', async () => {

--- a/test/CurveYieldStrategy.spec.ts
+++ b/test/CurveYieldStrategy.spec.ts
@@ -676,7 +676,7 @@ describe('CurveYieldStrategy', () => {
       const curveYieldStrategy = curveYieldStrategyTest.connect(admin);
       await curveYieldStrategy.grantAllowances();
 
-      await curveYieldStrategy.updateSetters(2_000, 1_000, 0, 3_000, addresses.CRV_ORACLE);
+      await curveYieldStrategy.updateCurveParams(2_000, 1_000, 0, 3_000, addresses.CRV_ORACLE);
       expect(await curveYieldStrategy.FEE()).to.be.eq(BigNumber.from(2000));
     });
 
@@ -687,7 +687,7 @@ describe('CurveYieldStrategy', () => {
       await curveYieldStrategy.grantAllowances();
 
       await expect(
-        curveYieldStrategyTest.updateSetters(10_001, 1_000, 0, 3_000, addresses.CRV_ORACLE),
+        curveYieldStrategyTest.updateCurveParams(10_001, 1_000, 0, 3_000, addresses.CRV_ORACLE),
       ).to.be.revertedWith('CYS_INVALID_SETTER_VALUE(10001)');
     });
 

--- a/test/fixtures/curve-yield-strategy.ts
+++ b/test/fixtures/curve-yield-strategy.ts
@@ -3,7 +3,6 @@ import { ERC20 } from '../../typechain-types/artifacts/@openzeppelin/contracts/t
 import {
   AggregatorV3Interface,
   CurveYieldStrategyTest__factory,
-  CurveYieldStrategy__factory,
   ICurveGauge,
   ICurveStableSwap,
   ILPPriceGetter,
@@ -71,11 +70,6 @@ export const curveYieldStrategyFixture = deployments.createFixture(async hre => 
     addresses.QUOTER,
   )) as ILPPriceGetter;
 
-  // const crvWethPool = (await hre.ethers.getContractAt(
-  //   '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol:IUniswapV3Pool',
-  //   '0xa95b0f5a65a769d82ab4f3e82842e45b8bbaf101',
-  // )) as IUniswapV3Pool;
-
   const uniswapQuoter = (await hre.ethers.getContractAt(
     '@uniswap/v3-periphery/contracts/interfaces/IQuoter.sol:IQuoter',
     '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
@@ -140,9 +134,7 @@ export const curveYieldStrategyFixture = deployments.createFixture(async hre => 
 
   await settlementToken.approve(clearingHouse.address, parseTokenAmount(10n ** 5n, 6));
 
-  await curveYieldStrategyTest.setCrvOracle(addresses.CRV_ORACLE);
-
-  await curveYieldStrategyTest.setCrvSwapSlippageTolerance(4_000);
+  await curveYieldStrategyTest.updateSetters(1_000, 1_000, 0, 4_000, addresses.CRV_ORACLE);
 
   return {
     crv,
@@ -155,7 +147,6 @@ export const curveYieldStrategyFixture = deployments.createFixture(async hre => 
     wethOracle,
     triCrypto,
     crvOracle,
-    // crvWethPool,
     uniswapQuoter,
     curveYieldStrategyTest,
   };

--- a/test/fixtures/curve-yield-strategy.ts
+++ b/test/fixtures/curve-yield-strategy.ts
@@ -134,7 +134,7 @@ export const curveYieldStrategyFixture = deployments.createFixture(async hre => 
 
   await settlementToken.approve(clearingHouse.address, parseTokenAmount(10n ** 5n, 6));
 
-  await curveYieldStrategyTest.updateSetters(1_000, 1_000, 0, 4_000, addresses.CRV_ORACLE);
+  await curveYieldStrategyTest.updateCurveParams(1_000, 1_000, 0, 4_000, addresses.CRV_ORACLE);
 
   return {
     crv,

--- a/test/fixtures/eighty-twenty-curve-strategy.ts
+++ b/test/fixtures/eighty-twenty-curve-strategy.ts
@@ -181,9 +181,6 @@ export const eightyTwentyCurveStrategyFixture = deployments.createFixture(async 
     tricryptoPool: addresses.TRICRYPTO_POOL,
   });
 
-  await curveYieldStrategyTest.grantAllowances();
-  await curveYieldStrategyTest.setCrvOracle(addresses.CRV_ORACLE);
-
   await curveYieldStrategyTest.setKeeper(admin.address);
   await collateralToken.grantRole(await collateralToken.MINTER_ROLE(), curveYieldStrategyTest.address);
   const vaultAccountNo = await curveYieldStrategyTest.rageAccountNo();
@@ -197,7 +194,9 @@ export const eightyTwentyCurveStrategyFixture = deployments.createFixture(async 
 
   await curveYieldStrategyTest.updateDepositCap(parseTokenAmount(10n ** 10n, 18));
 
-  await curveYieldStrategyTest.setCrvSwapSlippageTolerance(3_000);
+  await curveYieldStrategyTest.updateSetters(1_000, 1_000, 0, 3_000, addresses.CRV_ORACLE);
+
+  await curveYieldStrategyTest.grantAllowances();
 
   return {
     crv,

--- a/test/fixtures/eighty-twenty-curve-strategy.ts
+++ b/test/fixtures/eighty-twenty-curve-strategy.ts
@@ -116,7 +116,7 @@ export const eightyTwentyCurveStrategyFixture = deployments.createFixture(async 
   const crvOracle = (await hre.ethers.getContractAt(
     '@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol:AggregatorV3Interface',
     addresses.CRV_ORACLE,
-  )) as AggregatorV3Interface;
+  )) as unknown as AggregatorV3Interface;
 
   const lpOracle = (await hre.ethers.getContractAt(
     'contracts/interfaces/curve/ILPPriceGetter.sol:ILPPriceGetter',
@@ -194,7 +194,7 @@ export const eightyTwentyCurveStrategyFixture = deployments.createFixture(async 
 
   await curveYieldStrategyTest.updateDepositCap(parseTokenAmount(10n ** 10n, 18));
 
-  await curveYieldStrategyTest.updateSetters(1_000, 1_000, 0, 3_000, addresses.CRV_ORACLE);
+  await curveYieldStrategyTest.updateCurveParams(1_000, 1_000, 0, 3_000, addresses.CRV_ORACLE);
 
   await curveYieldStrategyTest.grantAllowances();
 

--- a/test/fixtures/ragetrade-core-integration.ts
+++ b/test/fixtures/ragetrade-core-integration.ts
@@ -21,7 +21,7 @@ export const rageTradeFixture = deployments.createFixture(async hre => {
   const clearingHouse = (await hre.ethers.getContractAt(
     '@ragetrade/core/contracts/protocol/clearinghouse/ClearingHouse.sol:ClearingHouse',
     rageTradeDeployments.ClearingHouseArbitrum.address,
-  )) as ClearingHouse;
+  )) as unknown as ClearingHouse;
   const settlementToken = (await hre.ethers.getContractAt(
     '@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20',
     addresses.USDC,

--- a/test/fixtures/ragetrade-core.ts
+++ b/test/fixtures/ragetrade-core.ts
@@ -19,7 +19,7 @@ export const rageTradeFixture = deployments.createFixture(async hre => {
   const clearingHouse = (await hre.ethers.getContractAt(
     '@ragetrade/core/contracts/protocol/clearinghouse/ClearingHouse.sol:ClearingHouse',
     rageTradeDeployments.ClearingHouse.address,
-  )) as ClearingHouse;
+  )) as unknown as ClearingHouse;
   const settlementToken = await hre.ethers.getContractAt(
     'SettlementTokenMock',
     rageTradeDeployments.SettlementToken.address,


### PR DESCRIPTION
- Combines all setters in `CurveYieldStrategy.sol` into a single setter and emits a single event to save bytecode size
- USDC <> USDT swap slippage as parameter instead of static value
- update fixtures and add test cases